### PR TITLE
using world-readable git URL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Either install as a gem, or install from github.
 
 ## Or, from github
 
-      $ git clone git@github.com:trogdoro/xiki.git
+      $ git clone https://github.com/trogdoro/xiki.git
       $ cd xiki
       $ sudo gem install bundler
       $ sudo bundle install --system


### PR DESCRIPTION
The original URL was R+W, so fails for those without commit rights.
