### PR TITLE
VIM: Preserve cursor position

### DIFF
--- a/etc/vim/xiki.vim
+++ b/etc/vim/xiki.vim
@@ -12,5 +12,5 @@ endfunction
 
 nmap <silent> <2-LeftMouse> :call XikiLaunch()<CR>
 imap <silent> <2-LeftMouse> <C-c>:call XikiLaunch()<CR>i
-imap <silent> <C-CR> <C-c>:call XikiLaunch()<CR>i
+imap <silent> <C-CR> <C-c>:call XikiLaunch()<CR>a
 nmap <silent> <C-CR> :call XikiLaunch()<CR>


### PR DESCRIPTION
Preserve cursor position in Vim when executing XikiLaunch from Insert mode
