### PR TITLE
Small fix for OSX

### DIFF
--- a/etc/install/el4r_setup.sh
+++ b/etc/install/el4r_setup.sh
@@ -1,4 +1,4 @@
-cd `dirname \`gem contents trogdoro-el4r | grep setup.rb\``
+cd `dirname \`gem contents --prefix trogdoro-el4r | grep setup.rb\``
 ruby setup.rb
 cd bin/
 ruby -S el4r-rctool -p


### PR DESCRIPTION
gem contents doesn't include the path, so el4r_setup.sh didn't work
