### PR TITLE
Elementary cygwin support

### DIFF
--- a/bin/xiki_process
+++ b/bin/xiki_process
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+
+xiki_dir = File.expand_path "#{File.dirname(__FILE__)}/.."
+$:.unshift "#{xiki_dir}/lib" #.sub(/\/$/, '')
+
+require "#{xiki_dir}/etc/command/xiki_process"
+
+XikiProcess.run

--- a/etc/command/xiki_process.rb
+++ b/etc/command/xiki_process.rb
@@ -1,26 +1,51 @@
-require 'xiki/core_ext'
-require 'xiki/menu'
-require 'xiki/launcher'
-
-Xiki.init
-
-# Make named pipes for input and output
+require 'daemons'
 
 class XikiProcess
 
+  def self.running?
+    files = Daemons::PidFile.find_files( "/tmp", "xiki_process" )
+    raise "Multiple PID files found for xiki_process!" if files.length > 1
+    return false if files.length == 0
+    pid_file = Daemons::PidFile.existing( files[0] )
+    Daemons::Pid.running? pid_file.pid() 
+  end
+
+  def self.start_daemon
+    xiki_dir = File.expand_path "#{File.dirname(__FILE__)}/../.."
+    begin
+      pid_orig = Process.pid
+      Daemons.run(
+        "#{xiki_dir}/bin/xiki_process",
+        :ARGV => ['start'],
+        :monitor => false,
+        :multiple => false,
+        :dir_mode => :normal,
+        :dir => "/tmp/",
+        :log_dir => "/tmp/",
+        :log_output => true
+      )
+    rescue SystemExit=>e
+      return
+    rescue Exception=>e
+      puts "- service couldn't start!:#{e.message}\n#{e.backtrace.join("\n")}\n\n"
+    end
+  end
+
   def self.run
 
-    open('/tmp/xikirequest', 'r+') do |f|
+    # We require these here so as not to slow down processes just wanting to do andilliary process stuff
+    require 'socket'
+    require 'xiki/core_ext'
+    require 'xiki/menu'
+    require 'xiki/launcher'
 
-      open('/tmp/xikiresponse', 'w+') do |response|
-        loop do
+    Xiki.init
 
-          # Read request...
-
-          path = XikiCommand.pop_initial_request || f.gets
+    server = TCPServer.open(22112)
+    loop do
+      Thread.start(server.accept) do |client|
+          path = client.gets
           path.strip!
-
-          # Invoke menu and send response...
 
           menu_output =
             begin
@@ -29,20 +54,13 @@ class XikiProcess
               "#{e.message}\n#{e.backtrace.join("\n")}"
             end
 
-          if menu_output.nil?
-            menu_output = ""
-          end
+          menu_output = "" if menu_output.nil?
 
           menu_output.gsub! "\n", "\036"   # Escape linebreaks as 036 char (record separator)
-          response.puts menu_output
-          response.flush
-        end
+          client.puts menu_output
       end
     end
-
   rescue Exception=>e
     puts "#{e.message}\n#{e.backtrace}"
   end
 end
-
-XikiProcess.run

--- a/lib/xiki/launcher.rb
+++ b/lib/xiki/launcher.rb
@@ -2,6 +2,18 @@ require 'xiki/effects'
 require 'xiki/requirer'
 require 'xiki'
 
+# ruby_parser 2.3.1 bug hack
+# https://github.com/seattlerb/ruby_parser/issues/18
+class Regexp
+  unless defined? ONCE then
+    ONCE     = 0 # 16 # ?
+    ENC_NONE = /x/n.options
+    ENC_EUC  = /x/e.options
+    ENC_SJIS = /x/s.options
+    ENC_UTF8 = /x/u.options
+  end
+end
+
 require 'sourcify'
 require 'ruby_parser'
 require 'file-tail'

--- a/lib/xiki/menu.rb
+++ b/lib/xiki/menu.rb
@@ -634,7 +634,7 @@ Ol << "location: #{location.inspect}"
       elsif line =~ /^[ +-]*@/ && Tree.has_child?   # If on ^@... line and there's child on next line...
         # Will grab the whole tree and move it up
         Tree.subtree.unindent.sub(/^[ @+-]+/, '')
-      elsif
+      else
         do_launch = true
         Tree.path.last
       end


### PR DESCRIPTION
This patch adds elementary cygwin support (i.e. xiki process runs and xiki command can talk to it and present responses to terminal).

The general gist of the changes are as follows:
- FIFO changed to TCPServer / TCPSocket - FIFOs were causing errors during flush on cygwin
- "running" check changed to use Daemon PID file checks as ps output does not contain script names on cygwin (plus it's a flakey way to check)
- xiki_process.rb refactored to allow inclusion without slowing down
- As a result of the above, xiki_process bin script created to execute the server
- Bug fix in lib/xiki/menu.rb that caused = vs == warning
- Hack for a bug in ruby_parser 2.3.1 to prevent redeclared constant errors
