### PR TITLE
A few vim improvements

### DIFF
--- a/etc/vim/xiki.vim
+++ b/etc/vim/xiki.vim
@@ -19,7 +19,7 @@ endif
 
 function! XikiLaunch()
   ruby << EOF
-    xiki_dir = ENV['XIKI_DIR']  || `xiki directory`.strip! unless defined? xiki_dir
+    xiki_dir ||= ENV['XIKI_DIR']  || `xiki directory`.strip!
     ['ol', 'vim/line', 'vim/tree'].each {|o| require "#{xiki_dir}/lib/xiki/#{o}"}
     line = Line.value
     indent = line[/^ +/]


### PR DESCRIPTION
4 changes:
1. check to see if `xiki_dir` is defined first, then try environment
   variable and finally use `'xiki directory'`
2. allow mappings to be skipped if `g:XikiUseDefaultMappings` is set to
   `0`
3. Only load the plugin once (though not really a big deal for the size
   it is now)
4. export the function `XikiLaunch()` as the command `XikiLaunch`
