### PR TITLE
Better Vim integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+# vim
+*.swp
+*.swo

--- a/etc/vim/vim_status.notes
+++ b/etc/vim/vim_status.notes
@@ -10,21 +10,20 @@
 > If your vim version doesn't have ruby enabled
 The standard macvim download has the ruby.  Compile vim with the --enable-rubyinterp flag installed.
 
-
 > What's implemented
-Just double-clicking on one line and shelling out to 'xiki'
+- Double-clicking on one line and shelling out to 'xiki'
 and inserting the results
-
-
-> What needs to be implemented
 - Making this work for nested paths, like:
 docs/
   - faq/
 - It needs to climb the path and pass it in to the command
 - Making it collapse when the line underneath it is indented lower
+
+> What needs to be done
+- Write documentation (doc/)
+- Check for Ruby and Vim versions
 - Making it incrementally search after commands are inserted
   - is there a command in vim to read 1 char from the user?
-
 
 > Help out
 Join the xiki google group if you want to help implement this.

--- a/etc/vim/xiki.vim
+++ b/etc/vim/xiki.vim
@@ -1,16 +1,34 @@
-function! XikiLaunch()
-  ruby << EOF
-    xiki_dir = ENV['XIKI_DIR']
-    ['ol', 'vim/line', 'vim/tree'].each {|o| require "#{xiki_dir}/lib/xiki/#{o}"}
-    line = Line.value
-    indent = line[/^ +/]
-    command = "xiki #{line}"
-    result = `#{command}`
-    Tree << result
-EOF
-endfunction
+if exists("loaded_xikivim")
+    finish
+endif
+" if v:version < 700
+"     echoerr "XikiVim: this plugin requires vim >= 7!"
+"     finish
+" endif
+let loaded_xikivim = 1
 
-nmap <silent> <2-LeftMouse> :call XikiLaunch()<CR>
-imap <silent> <2-LeftMouse> <C-c>:call XikiLaunch()<CR>i
-imap <silent> <C-CR> <C-c>:call XikiLaunch()<CR>i
-nmap <silent> <C-CR> :call XikiLaunch()<CR>
+function! XikiLaunch()
+  ruby << eoruby
+    # $".clear # dev
+    $XIKI_DIR ||= ENV['XIKI_DIR'] || %x,xiki directory,.strip
+
+    begin
+      require "#{$XIKI_DIR}/lib/xiki/vim.rb"
+    rescue LoadError
+      Vim.message("Couldn't find Xiki home!")
+      raise
+    end
+
+    path = XikiVim::construct_path $curbuf
+    XikiVim::take_action $curbuf, path
+eoruby
+endfunction
+command! XikiLaunch :call XikiLaunch()
+
+if !exists("xikivim_no_mappings")
+    inoremap <silent> <2-LeftMouse> <C-c>:XikiLaunch<CR>a
+    nnoremap <silent> <2-LeftMouse> <C-c>:XikiLaunch<CR>i
+    inoremap <silent> <Leader><Leader> <C-c>:XikiLaunch<CR>a
+    nnoremap <silent> <Leader><Leader> :XikiLaunch<CR>
+endif
+

--- a/lib/xiki/vim.rb
+++ b/lib/xiki/vim.rb
@@ -1,0 +1,80 @@
+module XikiVim
+  INDENT    = ' ' * 2
+  INDENT_RE = /^(\s*)/
+end
+
+%w{ vim/tree }.each do |lib|
+  require File.expand_path("../#{lib}", __FILE__)
+end
+
+module XikiVim
+  # go up until there is no whitespace
+  # returns built path + absolute row of root
+  def self.construct_path buffer
+    path       = ""
+    offset     = 0
+    line       = buffer.line_number
+    cur_id_lvl = 1e10
+
+    # build path as long as line starts with whitespaces
+    until (match = buffer[line + offset].match(/^(\s+)/)).nil?
+      line_id_lvl = match[1].length
+
+      # check if we reached a parent, and append it to path
+      if line_id_lvl < cur_id_lvl
+        path = sanitize(buffer[line + offset]) + path
+        cur_id_lvl = line_id_lvl
+      end
+      offset -= 1
+    end
+    path = sanitize(buffer[line + offset]) + "/" + path
+
+    return path
+  end
+
+  # FIXME error handling on shell out
+  def self.take_action buffer, path
+    ensure_format buffer
+
+    if expanded? buffer.line
+      buffer[buffer.line_number] = buffer.line.gsub(/-/, '+')
+      block(buffer, true)
+    else
+      # check cache
+      buffer[buffer.line_number] = buffer.line.gsub(/\+/, '-')
+      xiki_resp = %x{ xiki "#{path}" }
+      t = Tree.new xiki_resp
+      t.render buffer
+    end
+  end
+
+  protected
+  def self.expanded? line
+    line.lstrip[0].chr == '-'
+  end
+
+  def self.sanitize line
+    line.strip.gsub(/^\+\s*|^-\s*/, '')
+  end
+
+  # get the sub-block (indentation-wise), optionally delete it
+  def self.block vimbuffer, do_delete
+    id_level = vimbuffer.line[INDENT_RE, 1]
+    buffer   = ""
+    i        = vimbuffer.line_number + 1
+
+    while id_level < vimbuffer[i][INDENT_RE, 1]
+      buffer << vimbuffer[i]
+      do_delete ? vimbuffer.delete(i) : i += 1
+    end
+
+    return buffer
+  end
+
+  def self.ensure_format buffer
+    char = buffer.line.lstrip[0].chr
+    if char != '-' && char != '+'
+      buffer.line = '+ ' + buffer.line
+    end
+  end
+end

--- a/lib/xiki/vim/line.rb
+++ b/lib/xiki/vim/line.rb
@@ -1,8 +1,0 @@
-class Line
-  def self.number
-    $curbuf.line_number
-  end
-  def self.value
-    $curbuf.line
-  end
-end

--- a/lib/xiki/vim/tree.rb
+++ b/lib/xiki/vim/tree.rb
@@ -1,9 +1,77 @@
-class Tree
-  def self.<< txt
-    line_number, line = Line.number, Line.value
-    indent = line[/^ +/]
-    txt.split("\n").each_with_index do |line, i|
-      $curbuf.append(line_number + i, "#{indent}  #{line}")
+module XikiVim
+  class Tree
+    attr_accessor :value, :children
+
+    def initialize txt, consume_root = false
+      lines = txt.split("\n")
+
+      if consume_root
+        @value = lines.shift || ""
+      end
+
+      @children = if lines.empty?
+                    []
+                  else
+                    parse_result lines
+                  end
+    end
+
+    # returns a list of children given a txt, using indentation level
+    def parse_result lines
+      children   = []
+
+      # 1. from blob to string array
+      id_lvl     = lines.first[INDENT_RE, 1].length
+      buffer     = ""
+      lines.each do |line|
+        id = line[INDENT_RE, 1].length
+
+        # not direct children, buffer
+        if id > id_lvl
+          buffer += line + "\n"
+          next
+        end
+
+        # back to direct children id level, done buffering
+        # add buffered children to their parent (last children on stack)
+        if not buffer.empty?
+          children.last << "\n" << buffer
+          buffer = ""
+        end
+
+        children << line
+      end
+      # retrieve being parsed children
+      if not buffer.empty?
+        children.last << "\n" << buffer
+        buffer = ""
+      end
+
+      # 2. from string array to trees
+      children.map! do |line|
+        Tree.new line, true # create a new tree, consuming root
+      end
+
+      children
+    end
+
+    def render buffer, indent = nil, i = 0
+      if indent.nil?
+        indent = buffer.line.nil?? "" : buffer.line[INDENT_RE, 1]
+      end
+
+      if not @value.nil?
+        buffer.append buffer.line_number + i, indent + @value
+        i += 1
+      end
+
+      indent += INDENT
+      @children.each do |c|
+        i = c.render buffer, indent, i
+        i += 1
+      end
+
+      return i - 1
     end
   end
 end

--- a/tests/test_helpers.rb
+++ b/tests/test_helpers.rb
@@ -1,0 +1,6 @@
+def lib
+  File.expand_path '../../lib', __FILE__
+end
+
+$:.unshift lib
+

--- a/tests/vim/helpers.rb
+++ b/tests/vim/helpers.rb
@@ -1,0 +1,33 @@
+require File.expand_path('../../test_helpers.rb', __FILE__)
+require 'minitest/autorun'
+require 'xiki/vim'
+
+class FakeBuffer
+  attr_accessor :line_number
+
+  def initialize lines
+    @lines = lines
+    @line_number = 0
+  end
+
+  def [] ln
+    @lines[ln]
+  end
+
+  def append ln, l
+    @lines.insert ln, l
+  end
+
+  def line
+    @lines[@line_number]
+  end
+
+  def line= l
+    @lines[@line_number] = l
+  end
+
+  def dump
+    @lines.join("\n")
+  end
+end
+

--- a/tests/vim/tree_test.rb
+++ b/tests/vim/tree_test.rb
@@ -1,0 +1,52 @@
+require File.expand_path('../helpers.rb', __FILE__)
+require 'xiki/vim'
+
+class String
+  def n
+    self.gsub(/^\s*/, '').strip
+  end
+end
+
+module XikiVim
+  class TestTree < MiniTest::Unit::TestCase
+    def test_parse
+      docs_faq = <<eodocs
+docs/faq
+  + What is Xiki/
+  + What does Xiki stand for/
+  + What are Xiki's main dependencies/
+  + What's the best way to figure out how to do something/
+  + How can I keep up to date with the latest Xiki happenings/
+eodocs
+
+      what_xiki = <<eoxiki
+Xiki is an environment that can be used in several ways:
+
+- Shell terminal on steroids
+- Development environment for coding rails or node.js apps, etc.
+- Framework for making lightweight user interfaces
+eoxiki
+
+      empty = Tree.new ""
+      assert_equal 0, empty.children.length
+
+      iptree = Tree.new "192.168.0.14"
+      assert_equal 1, iptree.children.length
+
+      docstree = Tree.new docs_faq
+      assert_equal 1, docstree.children.length
+      assert_equal 5, docstree.children[0].children.length
+
+      buffer = FakeBuffer.new []
+      docstree.render(buffer)
+      assert_equal docs_faq.n, buffer.dump.n
+
+      buffer = FakeBuffer.new []
+      xikitree = Tree.new what_xiki
+      xikitree.render(buffer)
+      assert_equal what_xiki.n, buffer.dump.n
+    end
+  end
+end
+
+# vim: nowrap

--- a/tests/vim/vim_test.rb
+++ b/tests/vim/vim_test.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../helpers.rb', __FILE__)
+
+class TestVim < MiniTest::Unit::TestCase
+  def test_construct_path
+    ary = ['docs/faq', '  + What is Xiki/', '  + What does Xiki stand for/']
+    buffer = FakeBuffer.new ary
+    buffer.line_number = 1
+    assert_equal "docs/faq/What is Xiki/", XikiVim.construct_path(buffer)
+
+    ary = ['docs/faq']
+    buffer = FakeBuffer.new ary
+    assert_equal "docs/faq/", XikiVim::construct_path(buffer)
+
+    ary = ['ls      ']
+    buffer = FakeBuffer.new ary
+    assert_equal "ls/", XikiVim::construct_path(buffer)
+  end
+
+  def test_ensure_format
+    buffer = FakeBuffer.new ["docs"]
+    XikiVim::ensure_format buffer
+    assert_equal "+ docs", buffer.dump
+  end
+end
+
+# vim: nowrap


### PR DESCRIPTION
Hi Craig,

I watched your RubyConf talk yesterday and discovered Xiki.
Being a Vim user, I decided to help a bit with the integration.

**What I did**
- Gathered and improved small fixes from #36 and #19
- Nested commands (going up the tree)
- Expand  and collapse
- Got rid of vim/line (indirection didn't seem to be justified) and replaced vim/tree
- Provided tests for most of this
- (NOT ANYMORE, see below) Added some more test infrastructure (minitest, guard to rerun test automatically), I think it is good to enforce good practices at the project level, but do whatever you want with these!
- Updated vim status

**What I did not do**
- Filtering on additional key strokes, not sure how to approach this in Vim (but didn't look at your emacs implementation)

**Comments**
I strongly believe Xiki is the right way to interact with a computer, at least from a keyboard. I have always been a huge fan of CLI interfaces and seeing projects like yours is refreshing, but...
1. I find the shelling-out option too slow compared to the snappiness of your emacs demo.
   A TCP client/server model seems like the right thing to do, with most of the code being editor-agnostic with only thin editor-specific presentation layers.
2. I had trouble dealing with the codebase and gave up on reusing existing data structure after 15min of browsing. That's why I added XikiVim::Tree. Get rid of the $el already :)

Is there anything planned to address these issues?

Anyway, thank you and keep up the good work! :)
