### PR TITLE
Friendly error message if xiki_process.rb does not promptly respond after we start it

### DIFF
--- a/etc/command/xiki_command.rb
+++ b/etc/command/xiki_command.rb
@@ -99,7 +99,12 @@ class XikiCommand
     end
 
     if process_succeeded
-      puts self.get_response   # Get response first time
+      begin
+        puts self.get_response   # Get response first time
+      rescue Timeout::Error => e
+        warn "expected xiki_process.rb to respond after we started it, but it is not responding" 
+        raise
+      end
     end
 
     raise SystemExit.new


### PR DESCRIPTION
For some reason, it is possible to get an unhandled exception the first time you install xiki as xiki_process.rb is not quite ready to be spoken to :) 
