### PR TITLE
Fix location of keybindings

### DIFF
--- a/lib/xiki/keys.rb
+++ b/lib/xiki/keys.rb
@@ -129,7 +129,7 @@ class Keys
 
       | For all keyboard shortcuts, see where they're key_bindings.rb, where they're
       | defined:
-      - @$xiki/key_bindings.rb
+      - @$xiki/lib/xiki/key_bindings.rb
 
       > Keyboard shortcuts while searching
       | The seventh category, "search" has special behavior.  See:


### PR DESCRIPTION
The key bindings are located in @$xiki/lib/xiki/key_bindings.rb, not
@$xiki/key_bindings.rb.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
