### PR TITLE
xiki.gemspec needs to be updated

### DIFF
--- a/xiki.gemspec
+++ b/xiki.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.email = "craig.muth@gmail.com"
   s.extra_rdoc_files = [
     "LICENSE",
-    "README.markdown"
+    "README.md"
   ]
 
   s.rdoc_options += %w[--exclude etc/templates/.*]


### PR DESCRIPTION
...d, reflecting change in 86d3ed132407ec3852c01b1a6d5007263f608817

Changed 
  s.extra_rdoc_files = [
    "LICENSE",
    "README.markdown"
  ]

to
  s.extra_rdoc_files = [
    "LICENSE",
    "README.md"
  ]

Reflects changes made in commit 86d3ed132407ec3852c01b1a6d5007263f608817.

Otherwise, bundle install notes error of not having a valid gemspec.
