### PR TITLE
Fix bug if buffer has only 1 line

### DIFF
--- a/etc/vim/xiki.vim
+++ b/etc/vim/xiki.vim
@@ -6,7 +6,6 @@ function! XikiLaunch()
     include Xiki
 
     line = Line.value
-    next_line = Line.value 2
 
     indent = line[/^ +/]
     command = "xiki '#{line}'"


### PR DESCRIPTION
next_line was not used and caused an error in buffers with only 1 line.  If adding it back in, add checks for single-line buffers or modify line.rb to range check.
