### PR TITLE
removed unnecessary next_line var/line from xiki.vim

### DIFF
--- a/etc/vim/xiki.vim
+++ b/etc/vim/xiki.vim
@@ -6,7 +6,6 @@ function! XikiLaunch()
     include Xiki
 
     line = Line.value
-    next_line = Line.value 2
 
     indent = line[/^ +/]
     command = "xiki '#{line}'"


### PR DESCRIPTION
This line would cause issues if the command you were
attempting to run was on the last line of the file.

It didn't appear to be used anywhere.