### PR TITLE
Added hint to use 1.9.3 as default ruby version when using rvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Either install as a gem, or install from github.
 
       # Or, if you're using rvm...
       $ ruby etc/command/copy_xiki_command_to.rb /usr/local/bin/xiki
+      
+      # Make sure you are using 1.9.3 as your default ruby version in rvm (see https://groups.google.com/forum/#!topic/xiki/jHZu8upnosc)
+      $ rvm --default use 1.9.3
 
 ### Or, as a gem
 


### PR DESCRIPTION
Aquamacs will not start with el4r if your default ruby-version is not set to 1.9.3. Please see https://groups.google.com/forum/#!topic/xiki/jHZu8upnosc for details.
