### PR TITLE
first pass dockerfile for setting up xiki in a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+
+RUN apt-get update
+RUN apt-get -y install make
+RUN apt-get -y install git
+RUN apt-get -y install ruby1.9.3
+RUN gem1.9.3 install bundler
+ADD ./ xiki
+RUN cd xiki ; bundle
+RUN cd xiki ; ruby1.9.3 etc/command/copy_xiki_command_to.rb /usr/bin/xiki


### PR DESCRIPTION
Added a docker file to build a container that installs xiki.

Xiki seems to get built and installs, and some commands seem to work (xiki ip) but other commands produce errors (xiki docs/faq)

Probably needs some work but I'm proposing it here to inspire others to take a look