### PR TITLE
Dir length will be different after gsub when spaces are in path.

### DIFF
--- a/lib/xiki/core/menu.rb
+++ b/lib/xiki/core/menu.rb
@@ -1239,6 +1239,7 @@ module Xiki
     def self.source_glob dir
 
       name = File.basename dir
+      containing_dir_length = dir[/.*\//].length
 
       dir = dir.gsub ' ', '[ -_]'   # For spaces in menus, match source files with underscores or dashes, etc
       name.gsub! ' ', '[ -_]'
@@ -1246,7 +1247,6 @@ module Xiki
       list = Dir.glob ["#{dir}/", "#{dir}.*", "#{dir}/index.*", "#{dir}/#{name}_index.*"]
       return nil if list.empty?
 
-      containing_dir_length = dir[/.*\//].length
       list.each{|o| o.slice! 0..containing_dir_length-1}   # Chop off paths
       list
     end


### PR DESCRIPTION
Simple fix for a bug that happens if there are spaces in the path to xiki.
