### PR TITLE
Fix issues to make git-2.x working

### DIFF
--- a/lib/xiki/core/git.rb
+++ b/lib/xiki/core/git.rb
@@ -11,7 +11,7 @@ module Xiki
 
     def self.branch_name dir=nil
       dir ||= Tree.closest_dir
-      Console.run("git status", :sync=>true, :dir=>dir)[/# On branch (.+)/, 1]
+      Console.run("git status", :sync=>true, :dir=>dir)[/On branch (.+)/, 1]
     end
 
     def self.do_push

--- a/menu/git.rb
+++ b/menu/git.rb
@@ -104,7 +104,9 @@ module Xiki::Menu
     end
 
     def self.status *args
-      self.diff({:expand=>false}, *args)
+      options = yield
+      options[:expand] = false
+      self.diff(*args) {options}
     end
 
     def self.status_raw


### PR DESCRIPTION
- Changed the regexp to find the current branch to be compatible with
  git-2.0.0. It should be backward compatible with git-1.x
- Fixed option passing from the status menu to the diff method.

Git 2.0.0 drops the '#' in the output.

example:


> OSX 10.9 with git-2.0
$ git --version
  | git version 2.0.0
$ cd ~/playpen/xiki; git status
  | On branch git2-fixes
  | nothing to commit, working directory clean

> Ubuntu 12.04 with git 1.7
$ ssh derby git --version
  | git version 1.7.9.5
$ ssh derby 'cd src/bill; git status;'
  | # On branch rails
  | nothing to commit (working directory clean)


the other fix is for an error when asking the status. This is delegated to the diff method which takes a block as options, however no block is passed to the diff call.