### PR TITLE
Add missing punctuation on wiki.org

### DIFF
--- a/misc/xiki.org/xiki.org_bootstrap_source.notes
+++ b/misc/xiki.org/xiki.org_bootstrap_source.notes
@@ -42,7 +42,7 @@ xiki loc/
           |-Xiki: User Friendly Shell Commands
           |-Xiki: the Command Line Reimagined
         | <p style="font-size:35px; color:#8cf; padding-top:8px; line-height:47px;">
-          | The shell console reimagined Type notes, prototype, and program.
+          | The shell console reimagined. Type notes, prototype, and program.
           |-Shell commands are amazing! But they're hard to learn. Until now!
           |-A better way to run commands.
         | <p style="font-size:14px; text-align:top;">


### PR DESCRIPTION
Hi!

I just noticed a tiny typo/grammatical error on Xiki.org — looks like there's a missing period (exclamation point?) in the big tagline in the header.